### PR TITLE
Support for multiple managed worlds

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
@@ -109,7 +109,7 @@ public class BlockEventHandler implements Listener
         Block block = breakEvent.getBlock();
 
         //if the player is not in managed world, do nothing (let vanilla code and other plugins do whatever)
-        if (!player.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(player.getWorld())) return;
 
         //otherwise figure out which region that block is in
         Location blockLocation = block.getLocation();
@@ -151,7 +151,7 @@ public class BlockEventHandler implements Listener
         }
 
         //if not in managed world, do nothing
-        if (!from.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(from.getWorld())) return;
 
         //region posts are at sea level at the lowest, so no need to check build permissions under that
         if (from.getY() < PopulationDensity.instance.minimumRegionPostY) return;
@@ -180,7 +180,7 @@ public class BlockEventHandler implements Listener
         Block block = placeEvent.getBlock();
 
         //if not in managed world, do nothing
-        if (!player.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(player.getWorld())) return;
 
         Location blockLocation = block.getLocation();
 
@@ -246,7 +246,7 @@ public class BlockEventHandler implements Listener
         if (player == null || (!Tag.WALL_SIGNS.isTagged(block.getType()) && !Tag.SIGNS.isTagged(block.getType()))) return;
 
         //if the player is not in managed world, do nothing
-        if (!player.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(player.getWorld())) return;
 
         if (!this.nearRegionPost(block.getLocation(), RegionCoordinates.fromLocation(block.getLocation()), 1)) return;
 
@@ -258,7 +258,7 @@ public class BlockEventHandler implements Listener
     {
         Block pistonBlock = event.getBlock();
 
-        if (!pistonBlock.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(pistonBlock.getWorld())) return;
 
         RegionCoordinates pistonRegion = RegionCoordinates.fromLocation(pistonBlock.getLocation());
         if (this.nearRegionPost(pistonBlock.getLocation(), pistonRegion, PopulationDensity.instance.postProtectionRadius + 12))
@@ -280,7 +280,7 @@ public class BlockEventHandler implements Listener
     {
         Block pistonBlock = event.getBlock();
 
-        if (!pistonBlock.getWorld().equals(PopulationDensity.ManagedWorld)) return;
+        if (!PopulationDensity.ManagedWorlds.contains(pistonBlock.getWorld())) return;
 
         RegionCoordinates pistonRegion = RegionCoordinates.fromLocation(pistonBlock.getLocation());
         if (this.nearRegionPost(pistonBlock.getLocation(), pistonRegion, PopulationDensity.instance.postProtectionRadius + 12))
@@ -312,7 +312,7 @@ public class BlockEventHandler implements Listener
                 location.getBlockX() <= postLocation.getBlockX() + howClose &&
                 location.getBlockZ() >= postLocation.getBlockZ() - howClose &&
                 location.getBlockZ() <= postLocation.getBlockZ() + howClose &&
-                location.getBlockY() >= PopulationDensity.ManagedWorld.getHighestBlockYAt(postLocation) - 4
+                location.getBlockY() >= location.getWorld().getHighestBlockYAt(postLocation) - 4
         );
     }
 }

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -106,7 +106,8 @@ public class DataStore implements TabCompleter
         }
 
         //study region data and initialize both this.openRegionCoordinates and this.nextRegionCoordinates
-        for (World world : PopulationDensity.ManagedWorlds) {
+        for (World world : PopulationDensity.ManagedWorlds)
+        {
             this.findNextRegion(world);
 
             if (nameToCoordsMap.keySet().size() == 0)

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -21,7 +21,12 @@ package me.ryanhamshire.PopulationDensity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import org.apache.commons.lang.Validate;
-import org.bukkit.*;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Tag;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
@@ -42,8 +47,16 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DataStore implements TabCompleter
 {

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -61,7 +61,7 @@ public class DataStore implements TabCompleter
     private String[] messages;
 
     //currently open regions
-    private ConcurrentHashMap<World, RegionCoordinates> openRegionCoordinates = new ConcurrentHashMap<>();
+    private Map<World, RegionCoordinates> openRegionCoordinates = new ConcurrentHashMap<>();
 
     //coordinates of the next region which will be opened, if one needs to be opened
     private Map<World, RegionCoordinates> nextRegionCoordinates = new ConcurrentHashMap<>();

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -21,11 +21,7 @@ package me.ryanhamshire.PopulationDensity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import org.apache.commons.lang.Validate;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.Tag;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
@@ -46,14 +42,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DataStore implements TabCompleter
@@ -71,15 +60,15 @@ public class DataStore implements TabCompleter
     //in-memory cache for messages
     private String[] messages;
 
-    //currently open region
-    private RegionCoordinates openRegionCoordinates;
+    //currently open regions
+    private ConcurrentHashMap<World, RegionCoordinates> openRegionCoordinates = new ConcurrentHashMap<>();
 
     //coordinates of the next region which will be opened, if one needs to be opened
-    private RegionCoordinates nextRegionCoordinates;
+    private ConcurrentHashMap<World, RegionCoordinates> nextRegionCoordinates = new ConcurrentHashMap<>();
 
     //region data cache
-    private ConcurrentHashMap<String, RegionCoordinates> nameToCoordsMap = new ConcurrentHashMap<String, RegionCoordinates>();
-    private ConcurrentHashMap<RegionCoordinates, String> coordsToNameMap = new ConcurrentHashMap<RegionCoordinates, String>();
+    private ConcurrentHashMap<String, RegionCoordinates> nameToCoordsMap = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<RegionCoordinates, String> coordsToNameMap = new ConcurrentHashMap<>();
 
     //initialization!
     public DataStore(List<String> regionNames)
@@ -117,17 +106,18 @@ public class DataStore implements TabCompleter
         }
 
         //study region data and initialize both this.openRegionCoordinates and this.nextRegionCoordinates
-        this.findNextRegion();
+        for (World world : PopulationDensity.ManagedWorlds) {
+            this.findNextRegion(world);
 
-        //if no regions were loaded, create the first one
-        if (nameToCoordsMap.keySet().size() == 0)
-        {
-            PopulationDensity.AddLogEntry("Please be patient while I search for a good new player starting point!");
-            PopulationDensity.AddLogEntry("This initial scan could take a while, especially for worlds where players have already been building.");
-            this.addRegion();
+            if (nameToCoordsMap.keySet().size() == 0)
+            {
+                PopulationDensity.AddLogEntry("Please be patient while I search for a good new player starting point in \"" + world.getName() + "\"!");
+                PopulationDensity.AddLogEntry("This initial scan could take a while, especially for worlds where players have already been building.");
+                this.addRegion(world);
+            }
+
+            PopulationDensity.AddLogEntry("Open region: \"" + this.getRegionName(this.getOpenRegion(world)) + "\" at " + this.getOpenRegion(world).toString() + ".");
         }
-
-        PopulationDensity.AddLogEntry("Open region: \"" + this.getRegionName(this.getOpenRegion()) + "\" at " + this.getOpenRegion().toString() + ".");
     }
 
     //used in the spiraling code below (see findNextRegion())
@@ -140,7 +130,7 @@ public class DataStore implements TabCompleter
     //sets private variables for openRegion and nextRegion when it's done
     //this may look like black magic, but seriously, it produces a tight spiral on a grid
     //coding this made me reminisce about seemingly pointless computer science exercises in college
-    public int findNextRegion()
+    public int findNextRegion(World world)
     {
         //spiral out from region coordinates 0, 0 until we find coordinates for an uninitialized region
         int x = 0;
@@ -153,14 +143,14 @@ public class DataStore implements TabCompleter
         Direction direction = Direction.down;   //direction to search
         int sideLength = 1;                    //maximum number of regions to move in this direction before changing directions
         int side = 0;                            //increments each time we change directions.  this tells us when to add length to each side
-        this.openRegionCoordinates = new RegionCoordinates(0, 0);
-        this.nextRegionCoordinates = new RegionCoordinates(0, 0);
+        this.openRegionCoordinates.put(world, new RegionCoordinates(world, 0, 0));
+        this.nextRegionCoordinates.put(world, new RegionCoordinates(world, 0, 0));
 
         //while the next region coordinates are taken, walk the spiral
-        while (this.getRegionName(this.nextRegionCoordinates) != null)
+        while (this.getRegionName(this.nextRegionCoordinates.get(world)) != null)
         {
             //loop for one side of the spiral
-            for (int i = 0; i < sideLength && this.getRegionName(this.nextRegionCoordinates) != null; i++)
+            for (int i = 0; i < sideLength && this.getRegionName(this.nextRegionCoordinates.get(world)) != null; i++)
             {
                 regionCount++;
 
@@ -171,7 +161,7 @@ public class DataStore implements TabCompleter
                 else x++;
 
                 this.openRegionCoordinates = this.nextRegionCoordinates;
-                this.nextRegionCoordinates = new RegionCoordinates(x, z);
+                this.nextRegionCoordinates.put(world, new RegionCoordinates(world, x, z));
             }
 
             //after finishing a side, change directions
@@ -357,7 +347,7 @@ public class DataStore implements TabCompleter
     }
 
     //adds a new region, assigning it a name and updating local variables accordingly
-    public RegionCoordinates addRegion()
+    public RegionCoordinates addRegion(World world)
     {
         //first, find a unique name for the new region
         String newRegionName;
@@ -379,12 +369,12 @@ public class DataStore implements TabCompleter
 
         } while (this.getRegionCoordinates(newRegionName) != null);
 
-        this.privateNameRegion(this.nextRegionCoordinates, newRegionName);
+        this.privateNameRegion(this.nextRegionCoordinates.get(world), newRegionName);
 
         //find the next region in the spiral (updates this.openRegionCoordinates and this.nextRegionCoordinates)
-        this.findNextRegion();
+        this.findNextRegion(world);
 
-        return this.openRegionCoordinates;
+        return this.openRegionCoordinates.get(world);
     }
 
     //names a region, never throws an exception for name content
@@ -446,9 +436,9 @@ public class DataStore implements TabCompleter
     }
 
     //retrieves the open region's coordinates
-    public RegionCoordinates getOpenRegion()
+    public RegionCoordinates getOpenRegion(World world)
     {
-        return this.openRegionCoordinates;
+        return this.openRegionCoordinates.get(world);
     }
 
     //goes to disk to get the name of a region, given its coordinates
@@ -464,7 +454,7 @@ public class DataStore implements TabCompleter
     }
 
     //actually edits the world to create a region post at the center of the specified region
-    public void AddRegionPost(RegionCoordinates region) throws ChunkLoadException
+    public void AddRegionPost(World world, RegionCoordinates region) throws ChunkLoadException
     {
         //if region post building is disabled, don't do anything
         if (!PopulationDensity.instance.buildRegionPosts) return;
@@ -476,19 +466,19 @@ public class DataStore implements TabCompleter
         int y;
 
         //make sure data is loaded for that area, because we're about to request data about specific blocks there
-        PopulationDensity.GuaranteeChunkLoaded(x, z);
+        PopulationDensity.GuaranteeChunkLoaded(world, x, z);
 
         //sink lower until we find something solid
         //also ignore glowstone, in case there's already a post here!
         Material blockType;
 
         //find the highest block.  could be the surface, a tree, some grass...
-        y = PopulationDensity.ManagedWorld.getHighestBlockYAt(x, z) + 1;
+        y = world.getHighestBlockYAt(x, z) + 1;
 
         //posts fall through trees, snow, and any existing post looking for the ground
         do
         {
-            blockType = PopulationDensity.ManagedWorld.getBlockAt(x, --y, z).getType();
+            blockType = world.getBlockAt(x, --y, z).getType();
         }
         while (y > 0 && (blockType == Material.AIR ||
                 blockType == Material.OAK_LEAVES ||
@@ -536,7 +526,7 @@ public class DataStore implements TabCompleter
             {
                 for (int y1 = y + 1; y1 <= y + 5; y1++)
                 {
-                    Block block = PopulationDensity.ManagedWorld.getBlockAt(x1, y1, z1);
+                    Block block = world.getBlockAt(x1, y1, z1);
                     if (Tag.SIGNS.isTagged(block.getType()) || Tag.WALL_SIGNS.isTagged(block.getType()))
                         block.setType(Material.AIR);
                 }
@@ -550,7 +540,7 @@ public class DataStore implements TabCompleter
             {
                 for (int y1 = y + 1; y1 < y + 10; y1++)
                 {
-                    Block block = PopulationDensity.ManagedWorld.getBlockAt(x1, y1, z1);
+                    Block block = world.getBlockAt(x1, y1, z1);
                     if (block.getType() != Material.AIR) block.setType(Material.AIR);
                 }
             }
@@ -559,27 +549,27 @@ public class DataStore implements TabCompleter
         //Sometimes we don't clear high enough thanks to new ultra tall trees in jungle biomes
         //Instead of attempting to clear up to nearly 110 * 4 blocks more, we'll just see what getHighestBlockYAt returns
         //If it doesn't return our post's y location, we're setting it and all blocks below to air.
-        int highestBlockY = PopulationDensity.ManagedWorld.getHighestBlockYAt(x, z);
+        int highestBlockY = world.getHighestBlockYAt(x, z);
         while (highestBlockY > y)
         {
-            Block block = PopulationDensity.ManagedWorld.getBlockAt(x, highestBlockY, z);
+            Block block = world.getBlockAt(x, highestBlockY, z);
             if (block.getType() != Material.AIR)
                 block.setType(Material.AIR);
             highestBlockY--;
         }
 
         //build post
-        PopulationDensity.ManagedWorld.getBlockAt(x, y + 3, z).setType(PopulationDensity.instance.postMaterialTop);
-        PopulationDensity.ManagedWorld.getBlockAt(x, y + 2, z).setType(PopulationDensity.instance.postMaterialMidTop);
-        PopulationDensity.ManagedWorld.getBlockAt(x, y + 1, z).setType(PopulationDensity.instance.postMaterialMidBottom);
-        PopulationDensity.ManagedWorld.getBlockAt(x, y, z).setType(PopulationDensity.instance.postMaterialBottom);
+        world.getBlockAt(x, y + 3, z).setType(PopulationDensity.instance.postMaterialTop);
+        world.getBlockAt(x, y + 2, z).setType(PopulationDensity.instance.postMaterialMidTop);
+        world.getBlockAt(x, y + 1, z).setType(PopulationDensity.instance.postMaterialMidBottom);
+        world.getBlockAt(x, y, z).setType(PopulationDensity.instance.postMaterialBottom);
 
         //build outer platform
         for (int x1 = x - 2; x1 <= x + 2; x1++)
         {
             for (int z1 = z - 2; z1 <= z + 2; z1++)
             {
-                PopulationDensity.ManagedWorld.getBlockAt(x1, y, z1).setType(PopulationDensity.instance.outerPlatformMaterial);
+                world.getBlockAt(x1, y, z1).setType(PopulationDensity.instance.outerPlatformMaterial);
             }
         }
 
@@ -588,7 +578,7 @@ public class DataStore implements TabCompleter
         {
             for (int z1 = z - 1; z1 <= z + 1; z1++)
             {
-                PopulationDensity.ManagedWorld.getBlockAt(x1, y, z1).setType(PopulationDensity.instance.innerPlatformMaterial);
+                world.getBlockAt(x1, y, z1).setType(PopulationDensity.instance.innerPlatformMaterial);
             }
         }
 
@@ -600,35 +590,35 @@ public class DataStore implements TabCompleter
             //build a sign on top with region name (or wilderness if no name)
             if (regionName == null) regionName = getMessage(Messages.Wilderness);
             regionName = PopulationDensity.capitalize(regionName);
-            setSign(x, y + 4, z, BlockFace.NORTH, PopulationDensity.instance.topSignContent, "%regionName%", regionName);
+            setSign(world, x, y + 4, z, BlockFace.NORTH, PopulationDensity.instance.topSignContent, "%regionName%", regionName);
         }
 
         //If the side sign configuration is not null
         if (PopulationDensity.instance.sideSignContent != null)
         {
             //add a sign for the region to the north
-            regionName = this.getRegionName(new RegionCoordinates(region.x - 1, region.z));
+            regionName = this.getRegionName(new RegionCoordinates(world, region.x - 1, region.z));
             if (regionName == null) regionName = getMessage(Messages.Wilderness);
             regionName = PopulationDensity.capitalize(regionName);
-            setWallSign(x, y + 2, z + 1, BlockFace.SOUTH, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
+            setWallSign(world, x, y + 2, z + 1, BlockFace.SOUTH, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
 
             //add a sign for the region to the east
-            regionName = this.getRegionName(new RegionCoordinates(region.x, region.z - 1));
+            regionName = this.getRegionName(new RegionCoordinates(world, region.x, region.z - 1));
             if (regionName == null) regionName = getMessage(Messages.Wilderness);
             regionName = PopulationDensity.capitalize(regionName);
-            setWallSign(x - 1, y + 2, z, BlockFace.WEST, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
+            setWallSign(world, x - 1, y + 2, z, BlockFace.WEST, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
 
             //add a sign for the region to the south
-            regionName = this.getRegionName(new RegionCoordinates(region.x + 1, region.z));
+            regionName = this.getRegionName(new RegionCoordinates(world, region.x + 1, region.z));
             if (regionName == null) regionName = getMessage(Messages.Wilderness);
             regionName = PopulationDensity.capitalize(regionName);
-            setWallSign(x, y + 2, z - 1, BlockFace.NORTH, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
+            setWallSign(world, x, y + 2, z - 1, BlockFace.NORTH, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
 
             //add a sign for the region to the west
-            regionName = this.getRegionName(new RegionCoordinates(region.x, region.z + 1));
+            regionName = this.getRegionName(new RegionCoordinates(world, region.x, region.z + 1));
             if (regionName == null) regionName = getMessage(Messages.Wilderness);
             regionName = PopulationDensity.capitalize(regionName);
-            setWallSign(x + 1, y + 2, z, BlockFace.EAST, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
+            setWallSign(world, x + 1, y + 2, z, BlockFace.EAST, PopulationDensity.instance.sideSignContent, "%regionName%", regionName);
         }
 
         //if teleportation is enabled, also add a sign facing north and south for teleportation help
@@ -636,41 +626,41 @@ public class DataStore implements TabCompleter
         {
             if (PopulationDensity.instance.instructionsSignContent != null)
             {
-                setWallSign(x - 1, y + 3, z, BlockFace.WEST, PopulationDensity.instance.instructionsSignContent);
-                setWallSign(x + 1, y + 3, z, BlockFace.EAST, PopulationDensity.instance.instructionsSignContent);
+                setWallSign(world, x - 1, y + 3, z, BlockFace.WEST, PopulationDensity.instance.instructionsSignContent);
+                setWallSign(world, x + 1, y + 3, z, BlockFace.EAST, PopulationDensity.instance.instructionsSignContent);
             }
         }
 
         //custom signs
         if (PopulationDensity.instance.mainCustomSignContent != null)
         {
-            setWallSign(x, y + 3, z - 1, BlockFace.NORTH, PopulationDensity.instance.mainCustomSignContent);
+            setWallSign(world, x, y + 3, z - 1, BlockFace.NORTH, PopulationDensity.instance.mainCustomSignContent);
         }
 
         if (PopulationDensity.instance.northCustomSignContent != null)
         {
-            setWallSign(x - 1, y + 1, z, BlockFace.WEST, PopulationDensity.instance.northCustomSignContent);
+            setWallSign(world, x - 1, y + 1, z, BlockFace.WEST, PopulationDensity.instance.northCustomSignContent);
         }
 
         if (PopulationDensity.instance.southCustomSignContent != null)
         {
-            setWallSign(x + 1, y + 1, z, BlockFace.EAST, PopulationDensity.instance.southCustomSignContent);
+            setWallSign(world, x + 1, y + 1, z, BlockFace.EAST, PopulationDensity.instance.southCustomSignContent);
         }
 
         if (PopulationDensity.instance.eastCustomSignContent != null)
         {
-            setWallSign(x, y + 1, z - 1, BlockFace.NORTH, PopulationDensity.instance.eastCustomSignContent);
+            setWallSign(world, x, y + 1, z - 1, BlockFace.NORTH, PopulationDensity.instance.eastCustomSignContent);
         }
 
         if (PopulationDensity.instance.westCustomSignContent != null)
         {
-            setWallSign(x, y + 1, z + 1, BlockFace.SOUTH, PopulationDensity.instance.westCustomSignContent);
+            setWallSign(world, x, y + 1, z + 1, BlockFace.SOUTH, PopulationDensity.instance.westCustomSignContent);
         }
     }
 
-    private void setSign(int x, int y, int z, BlockFace blockFace, String[] lines, String... replacements)
+    private void setSign(World world, int x, int y, int z, BlockFace blockFace, String[] lines, String... replacements)
     {
-        Block block = PopulationDensity.ManagedWorld.getBlockAt(x, y, z);
+        Block block = world.getBlockAt(x, y, z);
         block.setType(Material.OAK_SIGN);
 
         org.bukkit.block.data.type.Sign wall = (org.bukkit.block.data.type.Sign)block.getBlockData();
@@ -692,9 +682,9 @@ public class DataStore implements TabCompleter
         s.update();
     }
 
-    private void setWallSign(int x, int y, int z, BlockFace blockFace, String[] lines, String... replacements)
+    private void setWallSign(World world, int x, int y, int z, BlockFace blockFace, String[] lines, String... replacements)
     {
-        Block block = PopulationDensity.ManagedWorld.getBlockAt(x, y, z);
+        Block block = world.getBlockAt(x, y, z);
         block.setType(Material.OAK_WALL_SIGN);
 
         org.bukkit.block.data.type.WallSign wall = (org.bukkit.block.data.type.WallSign)block.getBlockData();
@@ -734,7 +724,7 @@ public class DataStore implements TabCompleter
         HashMap<String, CustomizableMessage> defaults = new HashMap<String, CustomizableMessage>();
 
         //initialize defaults
-        this.addDefault(defaults, Messages.NoManagedWorld, "The PopulationDensity plugin has not been properly configured.  Please update your config.yml to specify a world to manage.", null);
+        this.addDefault(defaults, Messages.WorldNotManaged, "The current world is not listed as a managed world. Please update your config.yml to add it.", null);
         this.addDefault(defaults, Messages.NoBreakPost, "You can't break blocks this close to the region post.", null);
         this.addDefault(defaults, Messages.NoBreakSpawn, "You can't break blocks this close to a player spawn point.", null);
         this.addDefault(defaults, Messages.NoBuildPost, "You can't place blocks this close to the region post.", null);

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -64,7 +64,7 @@ public class DataStore implements TabCompleter
     private ConcurrentHashMap<World, RegionCoordinates> openRegionCoordinates = new ConcurrentHashMap<>();
 
     //coordinates of the next region which will be opened, if one needs to be opened
-    private ConcurrentHashMap<World, RegionCoordinates> nextRegionCoordinates = new ConcurrentHashMap<>();
+    private Map<World, RegionCoordinates> nextRegionCoordinates = new ConcurrentHashMap<>();
 
     //region data cache
     private ConcurrentHashMap<String, RegionCoordinates> nameToCoordsMap = new ConcurrentHashMap<>();

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -203,7 +203,7 @@ public class DataStore implements TabCompleter
         //initialize random number generator with a seed based the current time
         Random randomGenerator = new Random();
 
-        ArrayList<RegionCoordinates> possibleDestinations = new ArrayList<RegionCoordinates>();
+        List<RegionCoordinates> possibleDestinations = new ArrayList<>();
         for (RegionCoordinates coords : this.coordsToNameMap.keySet())
         {
             if (!coords.equals(regionToAvoid))

--- a/src/me/ryanhamshire/PopulationDensity/EntityEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/EntityEventHandler.java
@@ -91,7 +91,7 @@ public class EntityEventHandler implements Listener
 
         //otherwise if it's close to a region post
         Location regionCenter = PopulationDensity.getRegionCenter(region, false);
-        regionCenter.setY(PopulationDensity.ManagedWorld.getHighestBlockYAt(regionCenter));
+        regionCenter.setY(location.getWorld().getHighestBlockYAt(regionCenter));
         if (regionCenter.distanceSquared(location) < 225)  //225 = 15 * 15
         {
             explodeEvent.blockList().clear(); //All the noise and terror, none of the destruction (whew!).
@@ -135,7 +135,7 @@ public class EntityEventHandler implements Listener
         if (!saplings.contains(item.getType())) return;
 
         //only care about the newest region
-        if (!PopulationDensity.instance.dataStore.getOpenRegion().equals(RegionCoordinates.fromLocation(entity.getLocation())))
+        if (!PopulationDensity.instance.dataStore.getOpenRegion(event.getLocation().getWorld()).equals(RegionCoordinates.fromLocation(entity.getLocation())))
             return;
 
         //only replace these blocks with saplings
@@ -243,7 +243,7 @@ public class EntityEventHandler implements Listener
         //natural spawns may cause animal spawns to keep new player resources available
         if (reason == SpawnReason.NATURAL)
         {
-            if (PopulationDensity.ManagedWorld == null || event.getLocation().getWorld() != PopulationDensity.ManagedWorld)
+            if (!PopulationDensity.ManagedWorlds.contains(event.getLocation().getWorld()))
                 return;
 
             //when an animal naturally spawns, grow grass around it
@@ -256,7 +256,7 @@ public class EntityEventHandler implements Listener
             if (entity instanceof Monster && PopulationDensity.instance.respawnAnimals)
             {
                 //only do this if the spawn is in the newest region
-                if (!PopulationDensity.instance.dataStore.getOpenRegion().equals(RegionCoordinates.fromLocation(entity.getLocation())))
+                if (!PopulationDensity.instance.dataStore.getOpenRegion(entity.getWorld()).equals(RegionCoordinates.fromLocation(entity.getLocation())))
                     return;
 
                 //if it's on grass, there's a 1/100 chance it will also spawn a group of animals

--- a/src/me/ryanhamshire/PopulationDensity/Messages.java
+++ b/src/me/ryanhamshire/PopulationDensity/Messages.java
@@ -20,7 +20,7 @@ package me.ryanhamshire.PopulationDensity;
 
 public enum Messages
 {
-    NoManagedWorld,
+    WorldNotManaged,
     NoBreakPost,
     NoBreakSpawn,
     NoBuildPost,

--- a/src/me/ryanhamshire/PopulationDensity/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/PlayerEventHandler.java
@@ -226,7 +226,6 @@ public class PlayerEventHandler implements Listener
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onPlayerJoin(PlayerJoinEvent event)
     {
-
         Player joiningPlayer = event.getPlayer();
 
         PopulationDensity.instance.resetIdleTimer(joiningPlayer);
@@ -246,7 +245,7 @@ public class PlayerEventHandler implements Listener
             if (!joiningPlayer.hasPlayedBefore())
             {
                 // his home region is the open region
-                RegionCoordinates openRegion = this.dataStore.getOpenRegion();
+                RegionCoordinates openRegion = this.dataStore.getOpenRegion(joiningPlayer.getWorld());
                 playerData.homeRegion = openRegion;
                 PopulationDensity.AddLogEntry("Assigned new player "
                         + joiningPlayer.getName() + " to region "
@@ -284,7 +283,7 @@ public class PlayerEventHandler implements Listener
 
                 if (playerData.homeRegion == null)
                 {
-                    playerData.homeRegion = PopulationDensity.instance.dataStore.getOpenRegion();
+                    playerData.homeRegion = PopulationDensity.instance.dataStore.getOpenRegion(joiningPlayer.getWorld());
                 }
             }
 
@@ -349,7 +348,7 @@ public class PlayerEventHandler implements Listener
     {
         if (!PopulationDensity.instance.respawnInHomeRegion)
         {
-            if (PopulationDensity.ManagedWorld == respawnEvent.getRespawnLocation().getWorld())
+            if (PopulationDensity.ManagedWorlds.contains(respawnEvent.getRespawnLocation().getWorld()))
             {
                 PopulationDensity.removeMonstersAround(respawnEvent.getRespawnLocation());
             }
@@ -369,8 +368,7 @@ public class PlayerEventHandler implements Listener
             Location homeRegionCenter = PopulationDensity.getRegionCenter(playerData.homeRegion, false);
 
             // aim for two blocks above the highest block and teleport
-            homeRegionCenter.setY(PopulationDensity.ManagedWorld
-                    .getHighestBlockYAt(homeRegionCenter) + 2);
+            homeRegionCenter.setY(player.getWorld().getHighestBlockYAt(homeRegionCenter) + 2);
             respawnEvent.setRespawnLocation(homeRegionCenter);
 
             PopulationDensity.removeMonstersAround(homeRegionCenter);

--- a/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
+++ b/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
@@ -177,7 +177,7 @@ public class PopulationDensity extends JavaPlugin
 
         //build a list of normal environment worlds
         List<World> worlds = this.getServer().getWorlds();
-        ArrayList<World> normalWorlds = new ArrayList<World>();
+        List<World> normalWorlds = new ArrayList<World>();
         for (int i = 0; i < worlds.size(); i++)
         {
             if (worlds.get(i).getEnvironment() == Environment.NORMAL)

--- a/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
+++ b/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
@@ -202,9 +202,11 @@ public class PopulationDensity extends JavaPlugin
 
         this.managedWorldNames = config.getStringList("PopulationDensity.ManagedWorldNames");
         if (this.managedWorldNames.size() == 0) this.managedWorldNames = Collections.singletonList(defaultManagedWorldName);
-        for (String worldName : managedWorldNames) {
+        for (String worldName : managedWorldNames)
+        {
             World world = this.getServer().getWorld(worldName);
-            if (world == null || !normalWorlds.contains(world)) {
+            if (world == null || !normalWorlds.contains(world))
+            {
                 AddLogEntry("World \"" + worldName + "\" does not exist on this server.");
                 continue;
             }
@@ -511,7 +513,8 @@ public class PopulationDensity extends JavaPlugin
         //scan the open region for resources and open a new one as necessary
         //may open and close several regions before finally leaving an "acceptable" region open
         //this will repeat every six hours
-        for (World world : ManagedWorlds) {
+        for (World world : ManagedWorlds)
+        {
             this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new ScanOpenRegionTask(world), 5L, this.hoursBetweenScans * 60 * 60 * 20L);
         }
 

--- a/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
+++ b/src/me/ryanhamshire/PopulationDensity/PopulationDensity.java
@@ -47,7 +47,10 @@ import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 

--- a/src/me/ryanhamshire/PopulationDensity/RegionCoordinates.java
+++ b/src/me/ryanhamshire/PopulationDensity/RegionCoordinates.java
@@ -19,15 +19,18 @@
 package me.ryanhamshire.PopulationDensity;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 
 public class RegionCoordinates
 {
+    public World world;
     public int x;
     public int z;
 
     //basic boring stuff (yawn)
-    public RegionCoordinates(int x, int z)
+    public RegionCoordinates(World world, int x, int z)
     {
+        this.world = world;
         this.x = x;
         this.z = z;
     }
@@ -37,8 +40,8 @@ public class RegionCoordinates
     //TRIVIA!  despite the simplicity of this method, I got it badly wrong like 5 times before it was finally fixed
     public static RegionCoordinates fromLocation(Location location)
     {
-        //not managed world?  return null
-        if (!location.getWorld().equals(PopulationDensity.ManagedWorld)) return null;
+        //not managed world? return null
+        if (!PopulationDensity.ManagedWorlds.contains(location.getWorld())) return null;
 
         //keeping all regions the same size and arranging them in a strict grid makes this calculation supa-fast!
         //that's important because we do it A LOT as players move, build, break blocks, and more
@@ -48,7 +51,7 @@ public class RegionCoordinates
         int z = location.getBlockZ() / PopulationDensity.REGION_SIZE;
         if (location.getZ() < 0) z--;
 
-        return new RegionCoordinates(x, z);
+        return new RegionCoordinates(location.getWorld(), x, z);
     }
 
     //converts a string representing region coordinates to a proper region coordinates object
@@ -56,21 +59,20 @@ public class RegionCoordinates
     public RegionCoordinates(String string)
     {
         //split the input string on the space
-        String[] elements = string.split(" ");
+        String[] elements = string.split(",");
+        String[] coords = elements[1].split(" ");
 
-        //expect two elements - X and Z, respectively
-        String xString = elements[0];
-        String zString = elements[1];
+        this.world = PopulationDensity.ManagedWorlds.stream()
+                .filter((w) -> w.getName().equals(elements[0]))
+                .findFirst().orElse(PopulationDensity.ManagedWorlds.get(0));
 
-        //convert those to integer values
-        this.x = Integer.parseInt(xString);
-        this.z = Integer.parseInt(zString);
+        this.x = Integer.parseInt(coords[0]);
+        this.z = Integer.parseInt(coords[1]);
     }
 
     //opposite of above - converts region coordinates to a handy string
-    public String toString()
-    {
-        return Integer.toString(this.x) + " " + Integer.toString(this.z);
+    public String toString(){
+        return world.getName() + "," + Integer.toString(this.x) + " " + Integer.toString(this.z);
     }
 
     //compares two region coordinates to see if they match
@@ -83,7 +85,7 @@ public class RegionCoordinates
 
         RegionCoordinates coords = (RegionCoordinates)coordinatesToCompare;
 
-        return this.x == coords.x && this.z == coords.z;
+        return this.world == coords.world && this.x == coords.x && this.z == coords.z;
     }
 
     @Override

--- a/src/me/ryanhamshire/PopulationDensity/RegionCoordinates.java
+++ b/src/me/ryanhamshire/PopulationDensity/RegionCoordinates.java
@@ -85,7 +85,7 @@ public class RegionCoordinates
 
         RegionCoordinates coords = (RegionCoordinates)coordinatesToCompare;
 
-        return this.world == coords.world && this.x == coords.x && this.z == coords.z;
+        return this.world.equals(coords.world) && this.x == coords.x && this.z == coords.z;
     }
 
     @Override

--- a/src/me/ryanhamshire/PopulationDensity/ScanOpenRegionTask.java
+++ b/src/me/ryanhamshire/PopulationDensity/ScanOpenRegionTask.java
@@ -18,12 +18,20 @@
 
 package me.ryanhamshire.PopulationDensity;
 
+import org.bukkit.World;
+
 public class ScanOpenRegionTask implements Runnable
 {
+    private World world;
+
+    public ScanOpenRegionTask(World world) {
+        this.world = world;
+    }
+
     @Override
     public void run()
     {
         //start a scan on the currently open region
-        PopulationDensity.instance.scanRegion(PopulationDensity.instance.dataStore.getOpenRegion(), true);
+        PopulationDensity.instance.scanRegion(PopulationDensity.instance.dataStore.getOpenRegion(world), true);
     }
 }

--- a/src/me/ryanhamshire/PopulationDensity/ScanOpenRegionTask.java
+++ b/src/me/ryanhamshire/PopulationDensity/ScanOpenRegionTask.java
@@ -24,7 +24,8 @@ public class ScanOpenRegionTask implements Runnable
 {
     private World world;
 
-    public ScanOpenRegionTask(World world) {
+    public ScanOpenRegionTask(World world)
+    {
         this.world = world;
     }
 

--- a/src/me/ryanhamshire/PopulationDensity/ScanRegionTask.java
+++ b/src/me/ryanhamshire/PopulationDensity/ScanRegionTask.java
@@ -20,19 +20,22 @@ package me.ryanhamshire.PopulationDensity;
 
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
+import org.bukkit.World;
 
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class ScanRegionTask extends Thread
 {
+    private World world;
     private ChunkSnapshot[][] chunks;
     private boolean openNewRegions;
 
     private final int CHUNK_SIZE = 16;
 
-    public ScanRegionTask(ChunkSnapshot chunks[][], boolean openNewRegions)
+    public ScanRegionTask(World world, ChunkSnapshot chunks[][], boolean openNewRegions)
     {
+        this.world = world;
         this.chunks = chunks;
         this.openNewRegions = openNewRegions;
     }
@@ -73,7 +76,7 @@ public class ScanRegionTask extends Thread
         int playerBlocks = 0;
 
         //initialize a new array to track where we've been
-        int maxHeight = PopulationDensity.ManagedWorld.getMaxHeight();
+        int maxHeight = world.getMaxHeight();
         int x, y, z;
         x = y = z = 0;
         boolean[][][] examined = new boolean[this.chunks.length * CHUNK_SIZE][maxHeight][this.chunks.length * CHUNK_SIZE];
@@ -394,7 +397,7 @@ public class ScanRegionTask extends Thread
         }
 
         //now that we're done, notify the main thread
-        ScanResultsTask resultsTask = new ScanResultsTask(logEntries, openNewRegions);
+        ScanResultsTask resultsTask = new ScanResultsTask(world, logEntries, openNewRegions);
         PopulationDensity.instance.getServer().getScheduler().scheduleSyncDelayedTask(PopulationDensity.instance, resultsTask, 5L);
     }
 

--- a/src/me/ryanhamshire/PopulationDensity/ScanResultsTask.java
+++ b/src/me/ryanhamshire/PopulationDensity/ScanResultsTask.java
@@ -18,16 +18,19 @@
 
 package me.ryanhamshire.PopulationDensity;
 
+import org.bukkit.World;
+
 import java.util.ArrayList;
 
 public class ScanResultsTask implements Runnable
 {
+    private World world;
     private ArrayList<String> logEntries;
     private boolean openNewRegion;
 
-    public ScanResultsTask(ArrayList<String> logEntries, boolean openNewRegion)
+    public ScanResultsTask(World world, ArrayList<String> logEntries, boolean openNewRegion)
     {
-
+        this.world = world;
         this.logEntries = logEntries;
         this.openNewRegion = openNewRegion;
     }
@@ -42,7 +45,7 @@ public class ScanResultsTask implements Runnable
 
         if (this.openNewRegion)
         {
-            RegionCoordinates newRegion = PopulationDensity.instance.dataStore.addRegion();
+            RegionCoordinates newRegion = PopulationDensity.instance.dataStore.addRegion(world);
             PopulationDensity.instance.scanRegion(newRegion, true);
         }
     }

--- a/src/me/ryanhamshire/PopulationDensity/WorldEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/WorldEventHandler.java
@@ -70,7 +70,7 @@ public class WorldEventHandler implements Listener
         }
 
         //nothing more to do in worlds other than the managed world
-        if (chunk.getWorld() != PopulationDensity.ManagedWorld) return;
+        if (!PopulationDensity.ManagedWorlds.contains(chunk.getWorld())) return;
 
         //find the boundaries of the chunk
         Location lesserCorner = chunk.getBlock(0, 0, 0).getLocation();
@@ -87,7 +87,7 @@ public class WorldEventHandler implements Listener
             //create a task to build the post after 10 seconds
             try
             {
-                PopulationDensity.instance.dataStore.AddRegionPost(region);
+                PopulationDensity.instance.dataStore.AddRegionPost(chunk.getWorld(), region);
             }
             catch (ChunkLoadException ignored){}  //this should never happen, because the chunk is loaded (why else would onChunkLoad() be invoked?)
         }
@@ -170,7 +170,7 @@ public class WorldEventHandler implements Listener
             return;
 
         //nothing more to do in worlds other than the managed world
-        if (chunk.getWorld() != PopulationDensity.ManagedWorld) return;
+        if (PopulationDensity.ManagedWorlds.contains(chunk.getWorld())) return;
 
         //don't allow the new player spawn point chunk to unload
         //RoboMWM: provided keepSpawnRegionLoaded is set to true
@@ -182,7 +182,7 @@ public class WorldEventHandler implements Listener
         //if the region is the new player region
         //RoboMWM: Or if server owner wants to keep all region posts loaded...
         RegionCoordinates region = RegionCoordinates.fromLocation(lesserCorner);
-        if (region.equals(PopulationDensity.instance.dataStore.getOpenRegion()) || PopulationDensity.instance.config_keepAllRegionPostsLoaded)
+        if (region.equals(PopulationDensity.instance.dataStore.getOpenRegion(region.world)) || PopulationDensity.instance.config_keepAllRegionPostsLoaded)
         {
             Location regionCenter = PopulationDensity.getRegionCenter(region, false);
 


### PR DESCRIPTION
As I mentioned in #77, I thought it would be nice for PopulationDensity to support multiple managed worlds as opposed to only a single world. I know that such a big undertaking would be a large amount of work and might require lots of testing and many sets of eyes to observe the changes to code to make sure nothing would break, and everything would work the right way.

I am opening this PR with the rough changes I have so far, with the hopes that we can collectively get the ball rolling for this type of support!

Notable code changes:

- `PopulationDensity.ManagedWorld` has become `PopulationDensity.ManagedWorlds` and is now of type `List<World>`. I did my best to ensure any references or checks for `ManagedWorld` would now perform the proper reference or check inside `ManagedWorlds` (that is, to ensure that the player does not do something in one managed world that would affect another). Testing will be needed to ensure this is the case.
- `RegionCoordinates` now also contains a `world` property/field such that methods which require it can now be linked to the world they're for. It prevents needing to pass `World`s into every method, but if you do not like this, it can be removed. I also modified the `toString()`, `public RegionCoordinates(String string)`, and `equals()` methods to better accomodate and reflect these changes.
- A few small code changes here and there were made to better communicate that there can be multiple managed worlds. Some console logging makes note to add world info during region scans.
- DataStore has a small change, namely that region data files now are in the format `world,x z` instead of the previous `x z` format, to ensure regions are loaded for the right world. (See changes to `RegionCoordinates` for more info).
- Many others I might have missed

Do note that much of this code was written or hacked at in the wee morning hours as I was determined to create a working build before sleeping. I do apologies for any gross coding styles, and I greatly appreciate and welcome any changes to better suit your code style. I come from a C# background so I may have missed some common Java style choices.

The one caveat to all of this, however, is that it means that users will need to regenerate or modify their `config.yml` file to reflect this multiple-world change, otherwise their original managed world may not be detected. I'm sure that could simply be changed by adding a few lines of code to support either single or multiple worlds. It's up to you :)

There is a lot of changes here, so please do not hesitate to fix things or ask me why I did things the way I did. I'll answer to the best of my ability.