### PR TITLE
Extends protection to cover the base under the region post.

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
@@ -312,7 +312,7 @@ public class BlockEventHandler implements Listener
                 location.getBlockX() <= postLocation.getBlockX() + howClose &&
                 location.getBlockZ() >= postLocation.getBlockZ() - howClose &&
                 location.getBlockZ() <= postLocation.getBlockZ() + howClose &&
-                location.getBlockY() >= PopulationDensity.ManagedWorld.getHighestBlockYAt(postLocation) - 4
+                location.getBlockY() >= PopulationDensity.ManagedWorld.getHighestBlockYAt(postLocation) - 5
         );
     }
 }


### PR DESCRIPTION
As the Y returned by World#getHighestBlockYAt now reflects the highest non-air block, including transparent blocks, we need to extend the protection area down by 1 block (as the highest block is now 1 block above the sign).
Resolves #73 