### PR TITLE
fix editable signs on regionpost

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -811,6 +811,8 @@ public class DataStore implements TabCompleter
         this.addDefault(defaults, Messages.RegionAlreadyNamed, "This region already has a name.  To REname, use /RenameRegion.", null);
         this.addDefault(defaults, Messages.HopperLimitReached, "To prevent server lag, hoppers are limited to {0} per chunk.", "0: maximum hoppers per chunk");
         this.addDefault(defaults, Messages.OutsideWorldBorder, "The region you are attempting to teleport to is outside the world border.", null);
+        this.addDefault(defaults, Messages.NoEditPost, "You can't edit signs this close to the region post.", null);
+        this.addDefault(defaults, Messages.NoEditSpawn, "You can't edit signs this close to a player spawn point.", null);
         this.addDefault(defaults, Messages.Wilderness, "Wilderness", null);
 
         //load the config file

--- a/src/me/ryanhamshire/PopulationDensity/Messages.java
+++ b/src/me/ryanhamshire/PopulationDensity/Messages.java
@@ -65,5 +65,7 @@ public enum Messages
     RegionAlreadyNamed,
     HopperLimitReached,
     OutsideWorldBorder,
+    NoEditPost,
+    NoEditSpawn,
     Wilderness
 }


### PR DESCRIPTION
As mentioned in this issue https://github.com/MLG-Fortress/PopulationDensity/issues/106 the sigs can be edited by any player and they are not protected anymore. Although it is not very critical because the signs are regenerated every while and then. I think it is better to fix it.

I only added an extra event handler similar to the one used in onBlockBreak to protect a regionpost.

Tested on local paper-1.20.1-32.jar Server with op User and normal User

Thanks