### PR TITLE
Prevent sign editing using setEditable method

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
+++ b/src/me/ryanhamshire/PopulationDensity/BlockEventHandler.java
@@ -45,7 +45,7 @@ import org.bukkit.event.player.PlayerBucketEmptyEvent;
 
 public class BlockEventHandler implements Listener
 {
-    private static Set<Material> alwaysBreakableMaterials = new HashSet(Arrays.asList(
+    private static Set<Material> alwaysBreakableMaterials = new HashSet<>(Arrays.asList(
             Material.TALL_GRASS,
             Material.ROSE_BUSH,
             Material.LILAC,
@@ -81,7 +81,7 @@ public class BlockEventHandler implements Listener
             Material.SNOW_BLOCK
     ));
 
-    private static Set<Material> beds = new HashSet(Arrays.asList(
+    private static Set<Material> beds = new HashSet<>(Arrays.asList(
             Material.WHITE_BED,
             Material.ORANGE_BED,
             Material.MAGENTA_BED,
@@ -328,39 +328,6 @@ public class BlockEventHandler implements Listener
                     return;
                 }
             }
-        }
-    }
-
-    //when a player edit a placed sign...
-    @EventHandler(ignoreCancelled = true)
-    public void onSignEditEvent(SignChangeEvent editEvent) {
-        Player player = editEvent.getPlayer();
-
-        PopulationDensity.instance.resetIdleTimer(player);
-
-        Block block = editEvent.getBlock();
-
-        //if the player is not in managed world, do nothing (let vanilla code and other plugins do whatever)
-        if (!player.getWorld().equals(PopulationDensity.ManagedWorld)) return;
-
-        //otherwise figure out which region that block is in
-        Location blockLocation = block.getLocation();
-
-        //region posts are at sea level at the lowest, so no need to check build permissions under that
-        if (blockLocation.getBlockY() < PopulationDensity.instance.minimumRegionPostY) return;
-
-        RegionCoordinates blockRegion = RegionCoordinates.fromLocation(blockLocation);
-
-        //if too close to (or above) region post, send an error message
-        //note the ONLY way to edit around a region post is to have special permission
-        if (!player.hasPermission("populationdensity.buildbreakanywhere") && this.nearRegionPost(blockLocation, blockRegion, PopulationDensity.instance.postProtectionRadius))
-        {
-            if (PopulationDensity.instance.buildRegionPosts)
-                PopulationDensity.sendMessage(player, TextMode.Err, Messages.NoEditPost);
-            else
-                PopulationDensity.sendMessage(player, TextMode.Err, Messages.NoEditSpawn);
-            editEvent.setCancelled(true);
-            return;
         }
     }
 

--- a/src/me/ryanhamshire/PopulationDensity/DataStore.java
+++ b/src/me/ryanhamshire/PopulationDensity/DataStore.java
@@ -718,6 +718,7 @@ public class DataStore implements TabCompleter
                 line = line.replace(key, value);
             }
             s.setLine(i, color(line));
+            s.setEditable(false);
         }
         s.update();
     }
@@ -744,6 +745,7 @@ public class DataStore implements TabCompleter
                 line = line.replace(key, value);
             }
             s.setLine(i, color(line));
+            s.setEditable(false);
         }
         s.update();
     }
@@ -811,8 +813,6 @@ public class DataStore implements TabCompleter
         this.addDefault(defaults, Messages.RegionAlreadyNamed, "This region already has a name.  To REname, use /RenameRegion.", null);
         this.addDefault(defaults, Messages.HopperLimitReached, "To prevent server lag, hoppers are limited to {0} per chunk.", "0: maximum hoppers per chunk");
         this.addDefault(defaults, Messages.OutsideWorldBorder, "The region you are attempting to teleport to is outside the world border.", null);
-        this.addDefault(defaults, Messages.NoEditPost, "You can't edit signs this close to the region post.", null);
-        this.addDefault(defaults, Messages.NoEditSpawn, "You can't edit signs this close to a player spawn point.", null);
         this.addDefault(defaults, Messages.Wilderness, "Wilderness", null);
 
         //load the config file

--- a/src/me/ryanhamshire/PopulationDensity/Messages.java
+++ b/src/me/ryanhamshire/PopulationDensity/Messages.java
@@ -65,7 +65,5 @@ public enum Messages
     RegionAlreadyNamed,
     HopperLimitReached,
     OutsideWorldBorder,
-    NoEditPost,
-    NoEditSpawn,
     Wilderness
 }


### PR DESCRIPTION
While updating the plugin to Java 21 and Spigot 1.20, I noticed a better method to prevent sign editing without using events on region posts.