### PR TITLE
workflow, generate jar on tag

### DIFF
--- a/.github/workflows/plugin_build.yml
+++ b/.github/workflows/plugin_build.yml
@@ -1,0 +1,44 @@
+name: Build Plugin
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Extract version from pom.xml
+        run: echo "PLUGIN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+
+      - name: Prepare Version from Tag
+        run: |
+          # Removing the 'v' prefix from the tag
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+          if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: Tag version '$TAG_VERSION' does not match the version in pom.xml '$PLUGIN_VERSION'"
+            exit 1
+          fi
+
+      - name: Build with Maven
+        run: mvn clean package
+
+      - name: Add version to JAR file
+        run: mv target/PopulationDensity.jar target/PopulationDensity-${{ env.PLUGIN_VERSION }}.jar
+
+      - name: Upload plugin jar with version
+        uses: actions/upload-artifact@v2
+        with:
+          name: PopulationDensity-${{ env.PLUGIN_VERSION }}
+          path: target/PopulationDensity-${{ env.PLUGIN_VERSION }}.jar


### PR DESCRIPTION
- generate the plugin jar file `PopulationDensity-<version>.jar` when a *tag* is created
- the tag should have the following format "v<version>" and it must equal the plugin version from pom.xml file
- the jar file is uploaded in the artifacts