### PR TITLE
replace createExplosion which causing div by 0 in paper 1.21.10 by on…

### DIFF
--- a/src/me/ryanhamshire/PopulationDensity/DropShipTeleporter.java
+++ b/src/me/ryanhamshire/PopulationDensity/DropShipTeleporter.java
@@ -19,6 +19,8 @@
 package me.ryanhamshire.PopulationDensity;
 
 import org.bukkit.GameMode;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -61,23 +63,35 @@ public class DropShipTeleporter implements Listener
     public void onEntityDamage(EntityDamageEvent event)
     {
         Entity entity = event.getEntity();
-        //when an entity has fall damage immunity, it lasts for only ONE fall damage check
-        if (event.getCause() == EntityDamageEvent.DamageCause.FALL)
-        {
-            if (isFallDamageImmune(entity))
-            {
-                event.setCancelled(true);
-                removeFallDamageImmunity(entity);
-                if (entity.getType() == EntityType.PLAYER)
-                {
-                    Player player = (Player)entity;
-                    if (!player.hasPermission("populationdensity.teleportanywhere"))
-                    {
-                        player.getWorld().createExplosion(player.getLocation(), 0);
-                    }
-                }
-            }
-        }
+
+        if (event.getCause() != EntityDamageEvent.DamageCause.FALL) return;
+        if (!isFallDamageImmune(entity)) return;
+
+        // Prevent the fall damage
+        event.setCancelled(true);
+        removeFallDamageImmunity(entity);
+
+        if (entity.getType() != EntityType.PLAYER) return;
+
+        Player player = (Player) entity;
+
+        // Skip effect if they have permission to teleport anywhere
+        if (player.hasPermission("populationdensity.teleportanywhere")) return;
+
+        player.getWorld().spawnParticle(
+                Particle.EXPLOSION,
+                player.getLocation(),
+                1,
+                0.0, 0.0, 0.0,
+                0.0
+        );
+
+        player.getWorld().playSound(
+                player.getLocation(),
+                Sound.ENTITY_GENERIC_EXPLODE,
+                0.3f,
+                1.0f
+        );
     }
 
     HashSet<UUID> fallImmunityList = new HashSet<>();


### PR DESCRIPTION
replace createExplosion which causing div by 0 in paper 1.21.10 by only sound and particle effects - same result.

The error crash and restart the server when a player teleport.
<img width="2366" height="964" alt="image" src="https://github.com/user-attachments/assets/a6100bdb-8945-4b6d-bf95-efcf50a4f217" />


Debugging with chatgpt result:
```
 BEFORE EXPLOSION velocity = 0.0,-0.51,0.0
AFTER EXPLOSION velocity = NaN,NaN,NaN

The knockback calculation receives an invalid divisor → NaN

Boom: velocity becomes NaN → next tick → Paper crashes with:

x not finite

This is 100% caused by calling createExplosion inside the FALL damage event.


--- not sure about this

🧨 WHY Paper turns the velocity to NaN after createExplosion()

Inside explosion physics, Paper does this:

Calculates vector from explosion center to entity

Normalizes it

Applies knockback with:

vec = vec / distance


If distance = 0 (because player is EXACTLY at explosion origin):
→ division by 0
→ produces NaN / Infinity
→ Paper's new Vector.checkFinite() detects this
→ crash

Even with power = 0, Paper still performs the knockback math.

```